### PR TITLE
Allow extra keys by default using isOfShape, add isOfExactShape

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,14 @@ areNumbers([1, 2, null, 4, undefined]) // => true
 Create a validator that asserts that the given argument is an object,
 where each of the values of its keys correspond to the given shape.
 The shape is an object where the values are either new shapes or simple type checks.
+`isOfShape` allows objects that have extra keys.  See `isOfExactShape` to exclude
+objects having extra keys not defined by the shape.
 
 ```ts
 const isUser = isOfShape({ name: isString, age: isNumber })
 isUser({name: 'John', age: 21}) // => true
 isUser({name: 'John', years: 21}) // => false
+isUser({name: 'John', age: 21, years: 21}) // => true
 isUser({name: 'John'}) // => false
 
 const isCompany = isOfShape({
@@ -149,6 +152,19 @@ const isCompany = isOfShape({
   users: isArrayOf(isUser),
 })
 isCompany({name: 'Untitled', users: [{name: 'John', age: 21}]) // => true
+```
+
+### `isOfExactShape`
+
+The same as `isOfShape`, except that it excludes objects that have extra keys
+not defined by the shape.
+
+```ts
+const isUser = isOfExactShape({ name: isString, age: isNumber })
+isUser({name: 'John', age: 21}) // => true
+isUser({name: 'John', years: 21}) // => false
+isUser({name: 'John', age: 21, years: 21}) // => false
+isUser({name: 'John'}) // => false
 ```
 
 ### `pick`

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -175,20 +175,17 @@ describe(`isArrayOf`, () => {
   })
 })
 
-describe(`isObjectOfShape`, () => {
+describe(`isOfShape`, () => {
   describe(`asserting shape {foo: number}`, () => {
     const assert = tg.isOfShape({ foo: tg.isNumber })
     it(`returns true for an object matching the shape`, () => {
       expect(assert({ foo: 1 })).to.equal(true)
     })
-    it(`returns false for an object matching the shape with additional props`, () => {
-      expect(assert({ foo: 1, bar: 2 })).to.equal(false)
+    it(`returns true for an object matching the shape with additional props`, () => {
+      expect(assert({ foo: 1, bar: 2 })).to.equal(true)
     })
     it(`returns false for an object which does not match the shape`, () => {
       expect(assert({ bar: 2 })).to.equal(false)
-    })
-    it(`doesn't allow extra keys`, () => {
-      expect(assert({ foo: 1, bar: 2 })).to.equal(false)
     })
     it(`is correctly typed`, () => {
       let input: {} = {}
@@ -224,9 +221,9 @@ describe(`isObjectOfShape`, () => {
       const input = { foo: [1], bar: { bar: 'baz', qux: undefined } }
       expect(assert(input)).to.equal(false)
     })
-    it(`doesn't allow extra nested keys`, () => {
+    it(`allows extra nested keys`, () => {
       const input = { foo: [], bar: { baz: 'baz', qux: true, test: 'test' } }
-      expect(assert(input)).to.equal(false)
+      expect(assert(input)).to.equal(true)
     })
     it(`is correctly typed`, () => {
       let input: {} = {}
@@ -241,23 +238,35 @@ describe(`isObjectOfShape`, () => {
   })
 })
 
+describe('isOfExactShape', () => {
+  describe(`asserting shape {foo: number}`, () => {
+    const assert = tg.isOfExactShape({ foo: tg.isNumber })
+    it(`returns true for an object matching the shape`, () => {
+      expect(assert({ foo: 1 })).to.equal(true)
+    })
+    it(`returns false for an object matching the shape with additional props`, () => {
+      expect(assert({ foo: 1, bar: 2 })).to.equal(false)
+    })
+  })
+})
+
 describe(`pick`, () => {
   const a = 'a', b = 'b', c = 'c'
   it(`grabs only one key from a larger shape`, () => {
-    const superType = tg.isOfShape({ a: tg.isString, b: tg.isString })
+    const superType = tg.isOfExactShape({ a: tg.isString, b: tg.isString })
     const subType = tg.pick(superType, 'a')
     expect(subType({ a })).to.equal(true)
     expect(subType({ a, b })).to.equal(false)
   })
   it(`grabs a few keys from a larger shape`, () => {
-    const superType = tg.isOfShape({ a: tg.isString, b: tg.isString, c: tg.isString, d: tg.isString })
+    const superType = tg.isOfExactShape({ a: tg.isString, b: tg.isString, c: tg.isString, d: tg.isString })
     const subType = tg.pick(superType, 'a', 'b')
     expect(subType({ a })).to.equal(false, `Missing "b".`)
     expect(subType({ a, b })).to.equal(true)
     expect(subType({ a, b, c })).to.equal(false, `Extra "c".`)
   })
   it(`grabs everything from a larger shape`, () => {
-    const superType = tg.isOfShape({ a: tg.isString, b: tg.isString })
+    const superType = tg.isOfExactShape({ a: tg.isString, b: tg.isString })
     const subType = tg.pick(superType, 'a', 'b')
     expect(subType({ a })).to.equal(false, `Missing "a".`)
     expect(subType({ a, b })).to.equal(true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export function isOfShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape:
       if (typeof keyGuard == 'function') {
         return key in input && (keyGuard as any)(input[key])
       } else if (typeof keyGuard == 'object') {
-        return isOfShape(keyGuard)(input[key])
+        return isOfShape(keyGuard, exact)(input[key])
       }
     })
     if (!isNothingMissing) return false
@@ -227,7 +227,7 @@ export function partial<T extends Dict> (guard: GuardWithShape<T>): GuardWithSha
   for (const key of Object.keys(guard.shape)) {
     resultShape[key] = isOneOf(isUndefined, guard.shape[key] as any)
   }
-  return isOfShape(resultShape) as any
+  return isOfShape(resultShape, guard.exact) as any
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,11 +139,15 @@ export function isArrayOf<T> (itemGuard: Guard<T>): Guard<T[]> {
   return ((input: any) => Array.isArray(input) && input.every(itemGuard)) as Guard<T[]>
 }
 
+export function isOfExactShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape: T): GuardWithShape<Unshape<T>> {
+  return isOfShape<V,T>(shape, true)
+}
+
 /**
  * Create a validator that asserts that passed argument is an object of a certain shape.
  * Accepts an object of guards.
  */
-export function isOfShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape: T): GuardWithShape<Unshape<T>> {
+export function isOfShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape: T, exact: boolean = false): GuardWithShape<Unshape<T>> {
   const fn: any = (input: any): input is T => {
     if (typeof input != 'object') return false
     const isNothingMissing = Object.keys(shape).every((key) => {
@@ -155,9 +159,10 @@ export function isOfShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape:
       }
     })
     if (!isNothingMissing) return false
-    return Object.keys(input).length == Object.keys(shape).length
+    return !exact || Object.keys(input).length == Object.keys(shape).length
   }
   fn.shape = shape
+  fn.exact = exact
   return fn as GuardWithShape<Unshape<T>>
 }
 
@@ -183,7 +188,7 @@ export function pick<T extends Dict> (guard: GuardWithShape<T>, ...keys: Array<k
   for (const key of keys) {
     resultingShape[key] = guard.shape[key]
   }
-  return isOfShape(resultingShape) as any
+  return isOfShape(resultingShape, guard.exact) as any
 }
 
 
@@ -211,7 +216,7 @@ export function omit<T extends Dict> (guard: GuardWithShape<T>, ...keys: Array<k
       resultingShape[key] = guard.shape[key]
     }
   }
-  return isOfShape(resultingShape) as any
+  return isOfShape(resultingShape, guard.exact) as any
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type FromGuard<T> = T extends GuardWithShape<infer V> ? V :
 
 export type Guard<T> = (input: any) => input is T
 export type GuardWithKnownInputType <I, T extends I> = (input: I) => input is T
-export type GuardWithShape<T> = Guard<T> & { shape: Shape<T> }
+export type GuardWithShape<T> = Guard<T> & { shape: Shape<T>, exact: boolean }
 
 export type GuardOrShape<T> = T extends Primitive ? Guard<T> : Shape<T>
 export type Shape<T extends Dict> = { [key in keyof T]: GuardOrShape<T[key]> }


### PR DESCRIPTION
resolves #6 

When I started using type-guards, I spent about an hour trying to figure out why my object didn't match my defined shape using isOfShape.  I think intuitively the name 'isOfShape' sounds like duck-typing, and should include any object that is a superset of the defined shape.

However, I understand you also may be hesitant to make a breaking change.  I'm happy to rewrite this to your suggested non-breaking change of `isAtLeastShapeOf` in that case.