### PR TITLE
isOfShape doesn't crash with null input

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -190,6 +190,9 @@ describe(`isObjectOfShape`, () => {
     it(`doesn't allow extra keys`, () => {
       expect(assert({ foo: 1, bar: 2 })).to.equal(false)
     })
+    it(`returns false for null`, () => {
+      expect(assert(null)).to.equal(false)
+    })
     it(`is correctly typed`, () => {
       let input: {} = {}
       if (assert(input)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export function isArrayOf<T> (itemGuard: Guard<T>): Guard<T[]> {
  */
 export function isOfShape<V extends Dict, T extends Shape<V> = Shape<V>> (shape: T): GuardWithShape<Unshape<T>> {
   const fn: any = (input: any): input is T => {
-    if (typeof input != 'object') return false
+    if (input === null || typeof input != 'object') return false
     const isNothingMissing = Object.keys(shape).every((key) => {
       const keyGuard: any = (shape as any)[key]
       if (typeof keyGuard == 'function') {


### PR DESCRIPTION
typeof null === 'object', so the previous guard clause wasn't protected against null.