### PR TITLE
optional type guard

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -57,9 +57,8 @@ describe(`isNotNull`, () => {
       assert<IsExact<typeof value, string>>(true)
       assert<IsNullable<typeof value>>(false)
     } else {
-      assert<IsExact<typeof value, never>>(true) // https://stackoverflow.com/q/56949854/2131286
-      // assert<IsExact<typeof value, string | null>>(true)
-      // assert<IsNullable<typeof value>>(true)
+      assert<IsExact<typeof value, null>>(true)
+      assert<IsNullable<typeof value>>(true)
     }
   })
 })
@@ -76,9 +75,8 @@ describe(`isNotNullOrUndefined`, () => {
       assert<IsExact<typeof value, string>>(true)
       assert<IsNullable<typeof value>>(false)
     } else {
-      assert<IsExact<typeof value, never>>(true) // https://stackoverflow.com/q/56949854/2131286
-      // assert<IsExact<typeof value, string | null>>(true)
-      // assert<IsNullable<typeof value>>(true)
+      assert<IsExact<typeof value, null>>(true)
+      assert<IsNullable<typeof value>>(true)
     }
   })
 })

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -239,6 +239,48 @@ describe(`isOfShape`, () => {
       }
     })
   })
+  describe(`asserting shape {foo?: number}`, () => {
+    const assert = tg.isOfShape({
+      foo: tg.optional(tg.isNumber)
+    })
+    it(`returns true for an object matching the shape with a value`, () => {
+      const input = { foo: 1 }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns true for an object explicitly matching the shape with undefined`, () => {
+      const input = { foo: undefined }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns true for an object implicitly matching the shape with undefined`, () => {
+      const input = {}
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns false for an object with an invalid "foo"`, () => {
+      const input = { foo: 'a' }
+      expect(assert(input)).to.equal(false)
+    })
+    it(`allows extra nested keys when the object matching the shape with a value`, () => {
+      const input = { foo: 1, bar: 1 }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`allows extra nested keys when the object explicitly matching the shape with undefined`, () => {
+      const input = { foo: undefined, bar: 1 }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`allows extra nested keys when the object implicitly matching the shape with undefined`, () => {
+      const input = { bar: 1 }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`is correctly typed`, () => {
+      let input: {} = {}
+      if (assert(input)) {
+        try {
+          noop(input.foo?.toExponential())
+        } catch {
+        }
+      }
+    })
+  })
 })
 
 describe('isOfExactShape', () => {
@@ -249,6 +291,35 @@ describe('isOfExactShape', () => {
     })
     it(`returns false for an object matching the shape with additional props`, () => {
       expect(assert({ foo: 1, bar: 2 })).to.equal(false)
+    })
+  })
+  describe(`asserting shape {foo?: number}`, () => {
+    const assert = tg.isOfExactShape({
+      foo: tg.optional(tg.isNumber)
+    })
+    it(`returns true for an object matching the shape with a value`, () => {
+      const input = { foo: 1 }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns true for an object explicitly matching the shape with undefined`, () => {
+      const input = { foo: undefined }
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns true for an object implicitly matching the shape with undefined`, () => {
+      const input = {}
+      expect(assert(input)).to.equal(true)
+    })
+    it(`returns false for an object matching the shape with value with additional props`, () => {
+      const input = { foo: 1, bar: 1 }
+      expect(assert(input)).to.equal(false)
+    })
+    it(`returns false for an object explicitly matching the shape with undefined with additional props`, () => {
+      const input = { foo: undefined, bar: 1 }
+      expect(assert(input)).to.equal(false)
+    })
+    it(`returns false for an object implicitly matching the shape with undefined with additional props`, () => {
+      const input = { bar: 1 }
+      expect(assert(input)).to.equal(false)
     })
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type StringToBasic<T extends BasicString> =
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type Dict = Record<string, any>
 export type Predicate<Input = any> = (input: Input) => boolean
+export type Optional<T> = T | undefined;
 
 /**
  * A helper which allows you to utilize the type of validator without using the validator itself.
@@ -44,6 +45,8 @@ export type FromGuard<T> = T extends GuardWithShape<infer V> ? V :
 export type Guard<T> = (input: any) => input is T
 export type GuardWithKnownInputType <I, T extends I> = (input: I) => input is T
 export type GuardWithShape<T> = Guard<T> & { shape: Shape<T>, exact: boolean }
+
+export type OptionalGuard<T> = (input: unknown) => input is Optional<T>
 
 export type GuardOrShape<T> = T extends Primitive ? Guard<T> : Shape<T>
 export type Shape<T extends Dict> = { [key in keyof T]: GuardOrShape<T[key]> }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,14 +1,11 @@
 {
+  "extends": "./tsconfig.json",
   "exclude": [
     "**/*.spec.ts"
   ],
   "compilerOptions": {
-    "target": "es2015",
     "module": "commonjs",
-    "moduleResolution": "node",
     "declaration": true,
-    "outDir": "./dist/cjs",
-    "strict": true,
-    "esModuleInterop": true
+    "outDir": "./dist/cjs"
   }
 }

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -1,14 +1,11 @@
 {
+  "extends": "./tsconfig.json",
   "exclude": [
     "**/*.spec.ts"
   ],
   "compilerOptions": {
-    "target": "es2015",
     "module": "es2015",
-    "moduleResolution": "node",
     "declaration": true,
-    "outDir": "./dist/es2015",
-    "strict": true,
-    "esModuleInterop": true
+    "outDir": "./dist/es2015"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This adds the function `tg.optional` which takes a type guard as an argument and returns an optional version of that typegaurd.

This allows `isOfShape` to handle optional properties.

fix: #35 
re: #36

Guard | Type
---|---
tg.isOfShape({ a: tg.optional(tg.isNumber) }) | { a?: number }
tg.isOfShape({ a: tg.isOneOf(tg.isNumber, tg.isUndefined) }) | { a: number \| undefined }