### PR TITLE
feat: support `bigint` basic type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,12 @@ export const isBoolean = isOfBasicType('boolean')
 export const isSymbol = isOfBasicType('symbol')
 
 /**
+ * Create a validator that asserts the passed argument is of type `'bigint'`,
+ * just like `typeof input == 'bigint'`.
+ */
+export const isBigint = isOfBasicType('bigint')
+
+/**
  * Create a validator that asserts the passed argument is of type `'function'`,
  * just like `typeof input == 'function'`.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-export type BasicString = 'string' | 'boolean' | 'number' | 'object' | 'function' | 'symbol'
-export type Primitive = string | boolean | number | symbol
+export type BasicString = 'string' | 'boolean' | 'number' | 'object' | 'function' | 'symbol' | 'bigint'
+export type Primitive = string | boolean | number | symbol | bigint
 export type Basic = Primitive | object | Function
 
 export type BasicToString<T extends Basic> =
@@ -9,7 +9,8 @@ export type BasicToString<T extends Basic> =
         T extends Function ? 'function' :
           T extends object ? 'object' :
             T extends symbol ? 'symbol' :
-              never
+	      T extends bigint ? 'bigint' :
+                never
 
 export type StringToBasic<T extends BasicString> =
   T extends 'string' ? string :
@@ -18,7 +19,8 @@ export type StringToBasic<T extends BasicString> =
         T extends 'function' ? Function :
           T extends 'object' ? object :
             T extends 'symbol' ? symbol :
-              never
+	      T extends 'bigint' ? bigint :
+                never
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type Dict = Record<string, any>


### PR DESCRIPTION
The JavaScript language supports the `typeof` response of `bigint`, as documented on
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#description. This merge request adds support for this additional basic type.